### PR TITLE
Add Nokogiri dependency to gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'nokogiri'
 gem 'faraday'
 
 group :development do

--- a/clockwork.gemspec
+++ b/clockwork.gemspec
@@ -5,11 +5,13 @@ Gem::Specification.new do |s|
   s.version = "1.0.0"
   s.author = "Mediaburst"
   s.email = "hello@mediaburst.co.uk"
-  s.homepage = "http://www.clockworksms.com/" 
+  s.homepage = "http://www.clockworksms.com/"
   s.platform = Gem::Platform::RUBY
   s.summary = "Ruby Gem for the Clockwork API."
   s.description = "Ruby Gem for the Clockwork API. Send text messages with the easy to use SMS API from Mediaburst."
   s.files = FileList["lib/**/*.rb", "[A-Z]*"].to_a
+
+  s.add_dependency "nokogiri", "~> 1.5.2"
 
   s.add_development_dependency "rake-compiler"
   s.add_development_dependency "rspec"


### PR DESCRIPTION
Adding Nokogiri dependency to the gemspec, otherwise you need to require it manually in your application.
