### PR TITLE
fix for truncate and invalid_char_action values

### DIFF
--- a/lib/clockwork/api.rb
+++ b/lib/clockwork/api.rb
@@ -57,8 +57,11 @@ module Clockwork
     # Set to +true+ to trim the message content to the maximum length if it is too long.
     # @return [boolean] 
     # @note This can be overriden for specific Clockwork::SMS objects; if it is not set your account default will be used.
-    attr_accessor :truncate
-    
+    attr_reader :truncate
+
+    def truncate= value
+      @truncate = value ? 1 : 0 unless value.nil?
+    end
     # Whether to use SSL when connecting to the API.
     # Defaults to +true+
     # @return [boolean] 
@@ -77,6 +80,7 @@ module Clockwork
       
     def invalid_char_action= symbol
       raise( ArgumentError, "#{symbol} must be one of :error, :replace, :remove" ) unless [:error, :replace, :remove].include?(symbol.to_sym)
+      @invalid_char_action = [nil, :error, :replace, :remove].index(symbol.to_sym)
     end
     
     def concat= number
@@ -111,6 +115,8 @@ module Clockwork
       @use_ssl = true if @use_ssl.nil?
       @concat = 3 if @concat.nil? && @long
       @messages ||= Clockwork::MessageCollection.new( :api => self )
+      @invalid_char_action = [nil, :error, :replace, :remove].index(@invalid_char_action) if @invalid_char_action
+      @truncate = @truncate ? 1 : 0 unless @truncate.nil?
     end
     
     # Check the remaining credit for this account.

--- a/lib/clockwork/sms.rb
+++ b/lib/clockwork/sms.rb
@@ -35,8 +35,12 @@ module Clockwork
     # Set to +true+ to trim the message content to the maximum length if it is too long.
     # @return [boolean] 
     # @note If this option is set it overrides the global option specified in Clockwork::API for this SMS, if neither option is set your account default will be used.
-    attr_accessor :truncate
-        
+    attr_reader :truncate
+
+    def truncate= value
+      @truncate = value ? 1 : 0 unless value.nil?
+    end
+
     # What to do with any invalid characters in the message content. +:error+ will raise a Clockwork::InvalidCharacterException, +:replace+ will replace a small number of common invalid characters, such as the smart quotes used by Microsoft Office with a similar match, +:remove+ will remove invalid characters.
     # @raise ArgumentError - if value is not one of +:error+, +:replace+, +:remove+
     # @return [symbol] One of +error+, +:replace+, +:remove+ 
@@ -58,6 +62,8 @@ module Clockwork
     # Create a new SMS message.
     def initialize options = {}      
       options.each { |k, v| instance_variable_set "@#{k}", v } if options.kind_of?(Hash)
+      @invalid_char_action = [nil, :error, :replace, :remove].index(@invalid_char_action) if @invalid_char_action
+      @truncate = @truncate ? 1 : 0 unless @truncate.nil?
     end
     
     # Deliver the SMS message.


### PR DESCRIPTION
The values for the truncate and invalid_char_action are not posted as integers. This pull request converts those values to values accepted by the API. I'm not sure how to fix the documentation.
