### PR TITLE
Error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ end
 
 responses = api.deliver
 responses.each do |response|
-    puts response.client_id
+    puts response.message.client_id
     if response.success
         puts response.message_id
     else


### PR DESCRIPTION
In the bulk message delivery example, the code should reference response.message.client_id. The client_id is not stored in the response object.